### PR TITLE
Fix artifact export hash recomputation

### DIFF
--- a/app/export/storage.py
+++ b/app/export/storage.py
@@ -44,12 +44,10 @@ def write_artifact(artifact: ArtifactLike, base_dir: Path) -> Path:
     data = _to_dict(artifact)
 
     # ensure deterministic, truthful export_hash
-    export_hash = data.get("export_hash") or _compute_hash(data)
-    # if present but mismatched, correct it
-    if data.get("export_hash") != export_hash:
-        data["export_hash"] = export_hash
-    else:
-        data["export_hash"] = export_hash
+    # always recompute the hash from core fields so a stale or missing
+    # value on the input artifact cannot leak through.
+    export_hash = _compute_hash(data)
+    data["export_hash"] = export_hash
 
     airline = _sanitize_airline(data.get("airline"))
     month = _sanitize_month(data.get("month"))

--- a/fastapi_tests/test_export_storage.py
+++ b/fastapi_tests/test_export_storage.py
@@ -1,0 +1,25 @@
+import json
+from app.models import BidLayerArtifact, Layer, Filter
+from app.export.storage import write_artifact, _compute_hash
+
+
+def _sample_artifact():
+    return BidLayerArtifact(
+        airline='UAL',
+        format='PBS2',
+        month='2024-01',
+        layers=[Layer(n=1, filters=[Filter(type='PairingId', op='IN', values=['P1'])], prefer='YES')],
+        lint={'errors': [], 'warnings': []},
+        export_hash='WRONGHASH'
+    )
+
+
+def test_write_artifact_recomputes_hash(tmp_path):
+    artifact = _sample_artifact()
+    path = write_artifact(artifact, tmp_path)
+
+    # Exported file should have recomputed hash and matching filename
+    data = json.loads(path.read_text())
+    expected_hash = _compute_hash(data)
+    assert data['export_hash'] == expected_hash
+    assert path.name == f"{expected_hash}.json"


### PR DESCRIPTION
## Summary
- ensure artifact export hash is recomputed ignoring stale values
- add regression test for artifact hashing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a12f838c5c8332a18df074d0c7f872