### PR TITLE
Use weighted score for optimizer ranking

### DIFF
--- a/app/services/optimizer.py
+++ b/app/services/optimizer.py
@@ -71,10 +71,10 @@ def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
     return [
         CandidateSchedule(
             candidate_id=pid,
-            score=award,
+            score=winner_score,
             hard_ok=True,
             soft_breakdown={},
             pairings=[],
         )
-        for (score, _neg_i, pid) in winners
+        for (winner_score, _neg_i, pid) in winners
     ]

--- a/fastapi_tests/test_optimizer.py
+++ b/fastapi_tests/test_optimizer.py
@@ -1,0 +1,62 @@
+import pytest
+
+from app.services.optimizer import select_topk
+from app.models import (
+    FeatureBundle,
+    PreferenceSchema,
+    SoftPrefs,
+    ContextSnapshot,
+)
+
+
+def _build_bundle():
+    context = ContextSnapshot(
+        ctx_id="1",
+        pilot_id="p1",
+        airline="UAL",
+        base="DEN",
+        seat="FO",
+        equip=["7M8"],
+        seniority_percentile=0.5,
+        default_weights={"layovers": 1.0},
+    )
+
+    prefs = PreferenceSchema(
+        pilot_id="p1",
+        airline="UAL",
+        base="DEN",
+        seat="FO",
+        equip=["7M8"],
+        soft_prefs=SoftPrefs(layovers={"prefer": ["B"], "weight": 1.0}),
+    )
+
+    analytics = {
+        "base_stats": {
+            "A": {"award_rate": 0.8},
+            "B": {"award_rate": 0.7},
+        }
+    }
+
+    pairings = {
+        "pairings": [
+            {"id": "A_id", "layover_city": "A"},
+            {"id": "B_id", "layover_city": "B"},
+        ]
+    }
+
+    return FeatureBundle(
+        context=context,
+        preference_schema=prefs,
+        analytics_features=analytics,
+        compliance_flags={},
+        pairing_features=pairings,
+    )
+
+
+def test_select_topk_pref_weighting():
+    bundle = _build_bundle()
+    topk = select_topk(bundle, 2)
+
+    assert [c.candidate_id for c in topk] == ["B_id", "A_id"]
+    assert topk[0].score == pytest.approx(1.7)
+    assert topk[1].score == pytest.approx(1.3)


### PR DESCRIPTION
## Summary
- Ensure `select_topk` returns candidate schedules scored with preference weights
- Add unit test verifying layover preferences influence ranking

## Testing
- `pytest -q fastapi_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a132c8c52c833284674e2cb71a285f