### PR TITLE
Clarify process route behavior

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -115,7 +115,12 @@ def index():
 
 @bp.route("/process", methods=["POST", "GET"])
 def process():
-    """Process schedule file and preferences - main form handler"""
+    """Handle preference submission and redirect to appropriate page.
+
+    When called via POST, the submitted preferences are appended to the
+    query string and the user is redirected to the PBS results page. For
+    any other request method, the user is sent back to the index page.
+    """
     if request.method == "POST":
         preferences = request.form.get('preferences', '')
         return redirect(url_for('main.pbs_results', preferences=preferences))


### PR DESCRIPTION
## Summary
- Clarify `process` route docstring to describe preference-based redirects instead of schedule file handling.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a132caec1883329107b239094e7b6e