### PR TITLE
test: validate trip details in parser happy path

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,5 +4,12 @@ from schedule_parser import parse_schedule
 def test_csv_happy_path():
     sample = b"TripID,Days,Credit\n1234,3,18.50\n5678,2,12.25\n"
     result = parse_schedule(sample, "sample.csv")
+
+    assert len(result) == 2
+    assert result[0]["days"] == 3
+    assert result[0]["credit"] == 18.50
+    assert result[1]["days"] == 2
+    assert result[1]["credit"] == 12.25
+
     ids = [t["id"] for t in result]
     assert ids == ["1234", "5678"]


### PR DESCRIPTION
## Summary
- extend parser test to verify number of trips, days, and credit values

## Testing
- `pytest tests/test_parser.py::test_csv_happy_path -q` *(fails: ImportError: cannot import name 'db' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a132cbd71c8332a17361674b3df644