### PR TITLE
feat: add airline uniqueness to bid packets

### DIFF
--- a/scripts/migrate_bid_packets_airline.py
+++ b/scripts/migrate_bid_packets_airline.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Recreate bid_packets table with airline-based uniqueness.
+
+This lightweight migration drops the existing ``bid_packets`` table and
+recreates it using the current SQLAlchemy model definition, which now
+includes an ``airline`` column and a composite unique constraint on
+``(month_tag, airline)``.
+"""
+
+from src.core.app import create_app
+from src.core.models import db, BidPacket
+
+
+def migrate() -> None:
+    """Drop and recreate the bid_packets table."""
+    app = create_app()
+    with app.app_context():
+        # Remove old table if it exists
+        BidPacket.__table__.drop(db.engine, checkfirst=True)
+        # Create table with updated schema
+        BidPacket.__table__.create(db.engine, checkfirst=True)
+        print("bid_packets table recreated with airline column and composite uniqueness")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    migrate()
+

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -23,10 +23,15 @@ class BidPacket(db.Model):
     __tablename__ = 'bid_packets'
 
     id = db.Column(db.Integer, primary_key=True)
-    month_tag = db.Column(db.String(6), unique=True)
+    month_tag = db.Column(db.String(6))
+    airline = db.Column(db.String(50), nullable=False)
     filename = db.Column(db.String(255))
     file_data = db.Column(db.LargeBinary)
     upload_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint('month_tag', 'airline', name='uix_bid_packets_month_tag_airline'),
+    )
 
 class BidAnalysis(db.Model):
     __tablename__ = 'bid_analyses'


### PR DESCRIPTION
## Summary
- allow multiple bid packets per month by scoping uniqueness to airline
- add script to recreate bid_packets table with new airline column and composite unique constraint

## Testing
- `pytest`
- `pytest tests/test_admin.py` *(fails: ModuleNotFoundError: No module named 'extensions'; other assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a15e2ad0a083329c7746eeed3f6d2c