### PR TITLE
Use Pydantic models for rule packs with FAR117 and union sections

### DIFF
--- a/app/rules/engine.py
+++ b/app/rules/engine.py
@@ -6,9 +6,10 @@ from typing import Any
 import yaml
 
 from app.models import FeatureBundle
+from app.rules.models import HardRule, RulePack
 
 
-def load_rule_pack(path: str) -> dict[str, Any]:
+def load_rule_pack(path: str) -> RulePack:
     """Load a YAML rule pack, resolving relative paths robustly."""
     pth = Path(path)
     candidates = []
@@ -21,30 +22,35 @@ def load_rule_pack(path: str) -> dict[str, Any]:
         c = c.resolve()
         if c.exists():
             with open(c) as f:
-                return yaml.safe_load(f)
-    raise FileNotFoundError(f"Rule pack not found in any candidate: {[str(c) for c in candidates]}")
+                data = yaml.safe_load(f)
+            return RulePack.model_validate(data)
+    raise FileNotFoundError(
+        f"Rule pack not found in any candidate: {[str(c) for c in candidates]}"
+    )
 
-def _eval_hard(pref: dict[str, Any], pairing: dict[str, Any], rule: dict[str, Any]) -> bool:
-    rid = rule.get("id")
+def _eval_hard(
+    pref: dict[str, Any], pairing: dict[str, Any], rule: HardRule, pack: RulePack
+) -> bool:
+    rid = rule.id
     if rid == "FAR117_MIN_REST":
-        return (pairing.get("rest_hours", 999) >= 10)
+        return pairing.get("rest_hours", 999) >= pack.far117.min_rest_hours
     if rid == "NO_REDEYE_IF_SET":
         if pref.get("hard_constraints", {}).get("no_red_eyes"):
             return pairing.get("redeye") is False
         return True
     return True  # unknown hard rule → allow (fail-open for now)
 
-def validate_feasibility(bundle: FeatureBundle, rules: dict[str, Any]) -> dict[str, Any]:
+def validate_feasibility(bundle: FeatureBundle, rules: RulePack) -> dict[str, Any]:
     pref = bundle.preference_schema.model_dump()
     pairings = bundle.pairing_features.get("pairings", [])
     violations: list[dict[str, Any]] = []
     feasible: list[dict[str, Any]] = []
     for p in pairings:
         ok = True
-        for r in rules.get("hard", []):
-            if not _eval_hard(pref, p, r):
+        for r in rules.hard:
+            if not _eval_hard(pref, p, r, rules):
                 ok = False
-                violations.append({"pairing_id": p.get("id"), "rule": r.get("id")})
+                violations.append({"pairing_id": p.get("id"), "rule": r.id})
         if ok:
             feasible.append(p)
     return {"violations": violations, "feasible_pairings": feasible}

--- a/app/rules/models.py
+++ b/app/rules/models.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class FAR117(BaseModel):
+    """FAR117 regulatory parameters."""
+
+    min_rest_hours: int = 10
+
+
+class UnionRules(BaseModel):
+    """Union contract parameters."""
+
+    max_duty_hours_per_day: int | None = None
+    no_red_eyes: bool = False
+
+
+class HardRule(BaseModel):
+    """Schema for a hard rule entry."""
+
+    id: str
+    desc: str | None = None
+    when: str | None = None
+    check: str | None = None
+
+
+class SoftRule(BaseModel):
+    """Schema for a soft rule entry."""
+
+    id: str
+    weight: float | str | None = None
+    score: str | None = None
+    desc: str | None = None
+
+
+class RulePack(BaseModel):
+    """Top-level rule pack schema."""
+
+    version: str
+    airline: str
+    far117: FAR117 = Field(default_factory=FAR117)
+    union: UnionRules = Field(default_factory=UnionRules)
+    hard: list[HardRule] = Field(default_factory=list)
+    soft: list[SoftRule] = Field(default_factory=list)

--- a/rule_packs/UAL/2025.08.yml
+++ b/rule_packs/UAL/2025.08.yml
@@ -1,5 +1,9 @@
-version: 2025.08
+version: "2025.08"
 airline: UAL
+far117:
+  min_rest_hours: 10
+union:
+  max_duty_hours_per_day: 16
 hard:
   - id: FAR117_MIN_REST
     desc: Rest >= 10h


### PR DESCRIPTION
## Summary
- Add typed Pydantic models for rule packs, including FAR117 and union subsections
- Validate YAML rule packs via new models and integrate into engine
- Extend example rule pack with FAR117/union config and enforce min rest check through model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1d222c80083329e0b35a80c969a31