### PR TITLE
Cache rule pack loading with optional reload

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -26,6 +26,10 @@ from app.strategy.engine import propose_strategy
 router = APIRouter()
 
 
+RULE_PACK_PATH = "rule_packs/UAL/2025.08.yml"
+_RULES = load_rule_pack(RULE_PACK_PATH)
+
+
 @router.post("/validate", tags=["Validate"])
 def validate(payload: dict[str, Any]) -> dict[str, Any]:
     """
@@ -45,8 +49,11 @@ def validate(payload: dict[str, Any]) -> dict[str, Any]:
             compliance_flags={},
             pairing_features=payload["pairings"],
         )
-        rules = load_rule_pack("rule_packs/UAL/2025.08.yml")
-        return validate_feasibility(bundle, rules)
+        force = payload.get("force_reload", False)
+        global _RULES
+        if force:
+            _RULES = load_rule_pack(RULE_PACK_PATH, force_reload=True)
+        return validate_feasibility(bundle, _RULES)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 


### PR DESCRIPTION
## Summary
- cache rule pack YAML files in-memory and allow force reload
- reuse cached rule pack in validate endpoint with optional reload trigger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1d226b3348332baa1baa91b9abe20