### PR TITLE
feat: incorporate persona weights and seniority in optimizer

### DIFF
--- a/app/services/optimizer.py
+++ b/app/services/optimizer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 from operator import itemgetter
-from typing import Any
+from typing import Any, Dict
 
 from app.models import CandidateSchedule, FeatureBundle
 
@@ -56,6 +56,45 @@ def _get(obj: Any, name: str, default=None):
         pass
     return _to_dict(obj).get(name, default)
 
+
+DEFAULT_WEIGHTS: Dict[str, float] = {"award_rate": 1.0, "layovers": 1.0}
+
+PERSONA_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "family_first": {"layovers": 1.2},
+    "money_maker": {"award_rate": 1.2},
+    "commuter_friendly": {"layovers": 1.1},
+    "quality_of_life": {"layovers": 1.1},
+    "reserve_avoider": {},
+    "adventure_seeker": {"layovers": 1.2},
+}
+
+
+def _get_scoring_weights(bundle: FeatureBundle) -> Dict[str, float]:
+    """Return normalized scoring weights for available factors."""
+
+    source_d = _to_dict(_get(bundle.preference_schema, "source", {}))
+    persona = source_d.get("persona")
+
+    weights = DEFAULT_WEIGHTS.copy()
+    if persona in PERSONA_WEIGHTS:
+        weights.update(PERSONA_WEIGHTS[persona])
+
+    ctx_weights = _to_dict(_get(bundle.context, "default_weights", {}))
+    weights.update(ctx_weights)
+
+    total = sum(weights.values()) or 1.0
+    for k in list(weights.keys()):
+        weights[k] = weights[k] / total
+    return weights
+
+
+def _get_seniority_adjustment(bundle: FeatureBundle) -> float:
+    """Return multiplier based on pilot seniority."""
+
+    seniority = float(_get(bundle.context, "seniority_percentile", 0.0) or 0.0)
+    seniority = max(0.0, min(seniority, 1.0))
+    return 0.9 + 0.2 * seniority
+
 def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
     """
     Legacy-compatible Top-K selection:
@@ -64,16 +103,15 @@ def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
     - Stable ties by earlier input order
     - O(N log K)
     """
+    weights = _get_scoring_weights(bundle)
+    seniority_factor = _get_seniority_adjustment(bundle)
+
     # soft prefs / weights
     prefs_d = _to_dict(_get(bundle.preference_schema, "soft_prefs", {}))
     layovers_d = _to_dict(prefs_d.get("layovers"))
     prefer = set(layovers_d.get("prefer") or [])
-    avoid  = set(layovers_d.get("avoid") or [])
-
-    default_weights_d = _to_dict(_get(bundle.context, "default_weights", {}))
-    w = layovers_d.get("weight")
-    if w is None:
-        w = default_weights_d.get("layovers", 1.0)
+    avoid = set(layovers_d.get("avoid") or [])
+    pref_w = layovers_d.get("weight", 1.0)
 
     # award rates
     base_stats_d = _to_dict(_get(bundle.analytics_features, "base_stats", {}))
@@ -94,10 +132,10 @@ def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
             pref_score = 0.5
 
         breakdown = {
-            "award_rate": award,
-            "layovers": w * pref_score,
+            "award_rate": weights.get("award_rate", 0.0) * award,
+            "layovers": weights.get("layovers", 0.0) * pref_w * pref_score,
         }
-        score = sum(breakdown.values())
+        score = sum(breakdown.values()) * seniority_factor
         items.append((score, -i, pid, breakdown, p))  # stable: earlier wins ties
 
     winners = heapq.nlargest(K, items, key=itemgetter(0, 1))

--- a/fastapi_tests/test_optimizer.py
+++ b/fastapi_tests/test_optimizer.py
@@ -58,8 +58,8 @@ def test_select_topk_pref_weighting():
     topk = select_topk(bundle, 2)
 
     assert [c.candidate_id for c in topk] == ["B_id", "A_id"]
-    assert topk[0].score == pytest.approx(1.7)
-    assert topk[1].score == pytest.approx(1.3)
+    assert topk[0].score == pytest.approx(0.85)
+    assert topk[1].score == pytest.approx(0.65)
 
     # rationale should reflect top scoring factors
     assert len(topk[0].rationale) >= 2
@@ -69,3 +69,14 @@ def test_select_topk_pref_weighting():
     assert len(topk[1].rationale) >= 2
     assert "award_rate" in topk[1].rationale[0]
     assert "layovers" in topk[1].rationale[1]
+
+
+def test_weight_and_seniority_adjustment():
+    bundle = _build_bundle()
+    bundle.context.default_weights = {"award_rate": 2.0, "layovers": 1.0}
+    bundle.context.seniority_percentile = 1.0
+
+    topk = select_topk(bundle, 1)
+
+    expected = (0.7 * (2 / 3) + 1.0 * (1 / 3)) * 1.1
+    assert topk[0].score == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add normalized scoring weights based on persona and context
- factor pilot seniority into scoring and integrate into select_topk
- extend optimizer tests for weight normalization and seniority

## Testing
- `pytest fastapi_tests/test_optimizer.py -q`
- `pytest -q` *(fails: SyntaxError in app/rules/engine.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dd98e68833297a405c8ea553f1d