### PR TITLE
Improve select_topk to include pairing IDs and default limit

### DIFF
--- a/app/services/optimizer.py
+++ b/app/services/optimizer.py
@@ -56,9 +56,9 @@ def _get(obj: Any, name: str, default=None):
         pass
     return _to_dict(obj).get(name, default)
 
-def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
+def select_topk(bundle: FeatureBundle, K: int = 50) -> list[CandidateSchedule]:
     """
-    Legacy-compatible Top-K selection:
+    Legacy-compatible Top-K selection (default K=50):
     - DO NOT hard-filter here (legacy scored all pairings; later stages enforce rules)
     - Score = award_rate(city) + weight * pref(city) where pref∈{1.0, 0.5, 0.0}
     - Stable ties by earlier input order
@@ -102,7 +102,6 @@ def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
 
     winners = heapq.nlargest(K, items, key=itemgetter(0, 1))
 
-    # Keep pairings empty (legacy hashing behavior)
     result: list[CandidateSchedule] = []
     for winner_score, _neg_i, pid, breakdown, pairing in winners:
         result.append(
@@ -111,8 +110,11 @@ def select_topk(bundle: FeatureBundle, K: int) -> list[CandidateSchedule]:
                 score=winner_score,
                 hard_ok=True,
                 soft_breakdown=breakdown,
-                pairings=[],
+                pairings=[pid],
                 rationale=_generate_rationale(pairing, breakdown),
             )
         )
-    return result
+
+    # Ensure descending order and cap at K elements
+    result.sort(key=lambda c: c.score, reverse=True)
+    return result[:K]

--- a/fastapi_tests/test_optimizer.py
+++ b/fastapi_tests/test_optimizer.py
@@ -60,6 +60,8 @@ def test_select_topk_pref_weighting():
     assert [c.candidate_id for c in topk] == ["B_id", "A_id"]
     assert topk[0].score == pytest.approx(1.7)
     assert topk[1].score == pytest.approx(1.3)
+    assert topk[0].pairings == ["B_id"]
+    assert topk[1].pairings == ["A_id"]
 
     # rationale should reflect top scoring factors
     assert len(topk[0].rationale) >= 2


### PR DESCRIPTION
## Summary
- add default `K=50` to `select_topk`
- include pairing IDs in returned `CandidateSchedule` objects and ensure sorted top-K results
- expand optimizer test to check returned pairing IDs

## Testing
- `pytest fastapi_tests/test_optimizer.py`
- `pytest` *(fails: SyntaxError in `app/rules/engine.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dda03888332803f091d635e52a6