### PR TITLE
Improve select_topk to include pairing IDs and default limit

### DIFF
--- a/fastapi_tests/test_optimizer.py
+++ b/fastapi_tests/test_optimizer.py
@@ -60,6 +60,8 @@ def test_select_topk_pref_weighting():
     assert [c.candidate_id for c in topk] == ["B_id", "A_id"]
     assert topk[0].score == pytest.approx(1.7)
     assert topk[1].score == pytest.approx(1.3)
+    assert topk[0].pairings == ["B_id"]
+    assert topk[1].pairings == ["A_id"]
 
     # rationale should reflect top scoring factors
     assert len(topk[0].rationale) >= 2


### PR DESCRIPTION
## Summary
- add default `K=50` to `select_topk`
- include pairing IDs in returned `CandidateSchedule` objects and ensure sorted top-K results
- streamline return logic by relying on `heapq.nlargest` ordering

## Testing
- `pytest fastapi_tests/test_optimizer.py -q`
- `pytest fastapi_tests/test_rank_candidates.py -q`
- `pytest -q` *(fails: SyntaxError in `app/rules/engine.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dda03888332803f091d635e52a6