### PR TITLE
docs: document optimizer scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,110 @@ Legacy:
 Benchmark helper:
   PYTHONPATH=. python scripts/bench_10k.py
 
+## Optimizer Scoring
+
+### Scoring Factors
+
+The optimizer ranks candidate pairings using a weighted sum of:
+
+- **award_rate** – historical award likelihood for a layover city.
+- **layovers** – preference score for layover cities (1.0 prefer, 0.5 neutral, 0.0 avoid).
+
+### Persona Weights
+
+Default weights assign equal importance to all factors. Personas adjust these weights:
+
+| Persona | Adjustments |
+| ------- | ----------- |
+| family_first | layovers ×1.2 |
+| money_maker | award_rate ×1.2 |
+| commuter_friendly | layovers ×1.1 |
+| quality_of_life | layovers ×1.1 |
+| reserve_avoider | (no change) |
+| adventure_seeker | layovers ×1.2 |
+
+Weights are normalized so contributions sum to 1.0.
+
+### Seniority Adjustment
+
+Scores are multiplied by:
+
+```
+0.9 + 0.2 * seniority_percentile
+```
+
+The percentile is clamped between 0 and 1.
+
+### Example Optimize Request
+
+```json
+POST /optimize
+{
+  "feature_bundle": {
+    "context": {
+      "ctx_id": "ctx-u1",
+      "pilot_id": "u1",
+      "airline": "UAL",
+      "base": "EWR",
+      "seat": "FO",
+      "equip": ["73G"],
+      "seniority_percentile": 0.5,
+      "default_weights": {"layovers": 1.0}
+    },
+    "preference_schema": {
+      "pilot_id": "u1",
+      "airline": "UAL",
+      "base": "EWR",
+      "seat": "FO",
+      "equip": ["73G"],
+      "soft_prefs": {"layovers": {"prefer": ["SAN", "SJU"], "weight": 1.0}}
+    },
+    "analytics_features": {
+      "base_stats": {
+        "SAN": {"award_rate": 0.65},
+        "SJU": {"award_rate": 0.55}
+      }
+    },
+    "compliance_flags": {},
+    "pairing_features": {
+      "pairings": [
+        {"id": "P1", "layover_city": "SAN"},
+        {"id": "P2", "layover_city": "SJU"}
+      ]
+    }
+  },
+  "K": 5
+}
+```
+
+### Example Optimize Response
+
+```json
+{
+  "candidates": [
+    {
+      "candidate_id": "P1",
+      "score": 0.82,
+      "hard_ok": true,
+      "soft_breakdown": {"award_rate": 0.33, "layovers": 0.49},
+      "pairings": [],
+      "rationale": ["layovers contributed 0.49", "award_rate contributed 0.33"]
+    }
+  ]
+}
+```
+
+Scores and rationale vary with input data.
+
+### Configuration
+
+Required environment variables for development and optimizer usage:
+
+- `VECTORBID_API_KEY` – protects `/export` and other admin endpoints.
+- `OPENAI_API_KEY` – enables GPT-based ranking; without it the fallback model is used.
+- `EXPORT_DIR` – directory where `/export` writes files (default `exports`).
+- `PORT` – development server port (default `8000`).
+
 ## Security
 
 Admin bearer tokens are never written to logs in clear text. Only the first


### PR DESCRIPTION
## Summary
- document optimizer scoring factors, persona weight adjustments, and seniority scaling
- add example /optimize request/response payloads
- list required environment variables for running the optimizer

## Testing
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.ini` *(fails: fastapi_tests/test_rank_candidates.py::test_select_topk_handles_missing_data)*

------
https://chatgpt.com/codex/tasks/task_e_68a21690f02c83329062d9e4506f9836