### PR TITLE
test: cover optimizer weighting and rationale

### DIFF
--- a/fastapi_tests/test_optimizer.py
+++ b/fastapi_tests/test_optimizer.py
@@ -1,15 +1,11 @@
 import pytest
 
-from app.services.optimizer import select_topk
-from app.models import (
-    FeatureBundle,
-    PreferenceSchema,
-    SoftPrefs,
-    ContextSnapshot,
-)
+from app.services.optimizer import select_topk, SCORING_CATEGORIES, _get_scoring_weights
+from app.models import FeatureBundle, PreferenceSchema, SoftPrefs, ContextSnapshot
 
 
-def _build_bundle():
+def _build_bundle() -> FeatureBundle:
+    dw = {k: 1.0 for k in SCORING_CATEGORIES}
     context = ContextSnapshot(
         ctx_id="1",
         pilot_id="p1",
@@ -18,32 +14,54 @@ def _build_bundle():
         seat="FO",
         equip=["7M8"],
         seniority_percentile=0.5,
-        default_weights={"layovers": 1.0},
+        default_weights=dw,
     )
-
     prefs = PreferenceSchema(
         pilot_id="p1",
         airline="UAL",
         base="DEN",
         seat="FO",
         equip=["7M8"],
-        soft_prefs=SoftPrefs(layovers={"prefer": ["B"], "weight": 1.0}),
+        soft_prefs=SoftPrefs(
+            layovers={"prefer": ["B"], "weight": 1.0},
+            pairing_length={"prefer": ["short"], "weight": 1.0},
+            report_time={"prefer": ["early"], "weight": 1.0},
+            release_time={"prefer": ["early"], "weight": 1.0},
+            credit={"prefer": ["high"], "weight": 1.0},
+            weekend_priority={"prefer": ["weekend"], "weight": 1.0},
+            commutable={"prefer": ["yes"], "weight": 1.0},
+        ),
     )
-
     analytics = {
         "base_stats": {
             "A": {"award_rate": 0.8},
             "B": {"award_rate": 0.7},
         }
     }
-
     pairings = {
         "pairings": [
-            {"id": "A_id", "layover_city": "A"},
-            {"id": "B_id", "layover_city": "B"},
+            {
+                "id": "A_id",
+                "layover_city": "A",
+                "pairing_length": "long",
+                "report_time": "late",
+                "release_time": "late",
+                "credit": "low",
+                "weekend_priority": "weekday",
+                "commutable": "no",
+            },
+            {
+                "id": "B_id",
+                "layover_city": "B",
+                "pairing_length": "short",
+                "report_time": "early",
+                "release_time": "early",
+                "credit": "high",
+                "weekend_priority": "weekend",
+                "commutable": "yes",
+            },
         ]
     }
-
     return FeatureBundle(
         context=context,
         preference_schema=prefs,
@@ -53,30 +71,45 @@ def _build_bundle():
     )
 
 
-def test_select_topk_pref_weighting():
+def test_select_topk_scoring_and_rationale():
     bundle = _build_bundle()
-    topk = select_topk(bundle, 2)
+    topk = select_topk(bundle)
 
     assert [c.candidate_id for c in topk] == ["B_id", "A_id"]
-    assert topk[0].score == pytest.approx(0.85)
-    assert topk[1].score == pytest.approx(0.65)
+    assert topk[0].pairings == ["B_id"]
+    assert topk[1].pairings == ["A_id"]
 
-    # rationale should reflect top scoring factors
-    assert len(topk[0].rationale) >= 2
-    assert "layovers" in topk[0].rationale[0]
-    assert "award_rate" in topk[0].rationale[1]
+    assert set(topk[0].soft_breakdown.keys()) == set(SCORING_CATEGORIES)
+    assert topk[0].score == pytest.approx(0.9625)
+    assert topk[1].score == pytest.approx(0.5375)
 
-    assert len(topk[1].rationale) >= 2
-    assert "award_rate" in topk[1].rationale[0]
-    assert "layovers" in topk[1].rationale[1]
+    max_val = max(topk[0].soft_breakdown.values())
+    top_cats = {k for k, v in topk[0].soft_breakdown.items() if v == max_val}
+    assert len(topk[0].rationale) == 3
+    for msg in topk[0].rationale:
+        factor = msg.split()[0]
+        assert factor in top_cats
+
+    assert topk[1].rationale[0].startswith("award_rate")
 
 
-def test_weight_and_seniority_adjustment():
+def test_persona_weighting_behavior():
     bundle = _build_bundle()
-    bundle.context.default_weights = {"award_rate": 2.0, "layovers": 1.0}
+    bundle.context.default_weights = {k: 0.0 for k in SCORING_CATEGORIES if k != "layovers"}
+    bundle.context.default_weights.update({"award_rate": 1.0})
+    bundle.preference_schema.source = {"persona": "family_first"}
+    weights = _get_scoring_weights(bundle)
+    assert weights["layovers"] > weights["award_rate"]
+
+
+def test_seniority_adjustment():
+    bundle = _build_bundle()
+    dw = {k: 0.0 for k in SCORING_CATEGORIES}
+    dw.update({"award_rate": 2.0, "layovers": 1.0})
+    bundle.context.default_weights = dw
     bundle.context.seniority_percentile = 1.0
 
     topk = select_topk(bundle, 1)
-
     expected = (0.7 * (2 / 3) + 1.0 * (1 / 3)) * 1.1
     assert topk[0].score == pytest.approx(expected)
+    assert topk[0].pairings == ["B_id"]

--- a/fastapi_tests/test_rank_candidates.py
+++ b/fastapi_tests/test_rank_candidates.py
@@ -1,10 +1,12 @@
 import pytest
 
-from app.services.optimizer import select_topk
+from app.services.optimizer import select_topk, SCORING_CATEGORIES
 from app.models import FeatureBundle, PreferenceSchema, ContextSnapshot, SoftPrefs
 
 
 def _bundle() -> FeatureBundle:
+    dw = {k: 0.0 for k in SCORING_CATEGORIES}
+    dw.update({"layovers": 1.0, "award_rate": 1.0})
     ctx = ContextSnapshot(
         ctx_id="ctx",
         pilot_id="p1",
@@ -13,7 +15,7 @@ def _bundle() -> FeatureBundle:
         seat="FO",
         equip=["7M8"],
         seniority_percentile=0.6,
-        default_weights={"layovers": 1.0},
+        default_weights=dw,
     )
     prefs = PreferenceSchema(
         pilot_id="p1",
@@ -46,19 +48,21 @@ def _bundle() -> FeatureBundle:
 
 def test_select_topk_deterministic():
     bundle = _bundle()
-    first = select_topk(bundle, 2)
-    second = select_topk(bundle, 2)
+    first = select_topk(bundle)
+    second = select_topk(bundle)
 
     assert [c.score for c in first] == [c.score for c in second]
     assert first[0].score >= first[1].score
     assert [c.candidate_id for c in first] == ["A", "B"]
-    assert first[0].pairings == []
+    assert first[0].pairings == ["A"]
     assert "award_rate" in first[0].soft_breakdown
     assert 0.0 <= first[0].score <= 2.0
     assert first[0].rationale
 
 
 def test_select_topk_handles_missing_data():
+    dw = {k: 0.0 for k in SCORING_CATEGORIES}
+    dw.update({"layovers": 1.0, "award_rate": 1.0})
     ctx = ContextSnapshot(
         ctx_id="ctx",
         pilot_id="p1",
@@ -67,7 +71,7 @@ def test_select_topk_handles_missing_data():
         seat="FO",
         equip=["7M8"],
         seniority_percentile=0.6,
-        default_weights={"layovers": 1.0},
+        default_weights=dw,
     )
     prefs = PreferenceSchema(
         pilot_id="p1",
@@ -85,7 +89,7 @@ def test_select_topk_handles_missing_data():
         pairing_features={"pairings": [{"id": "X"}]},
     )
     ranked = select_topk(bundle, 1)
-    assert ranked[0].soft_breakdown["award_rate"] == pytest.approx(0.5)
-    assert ranked[0].soft_breakdown["layovers"] == pytest.approx(0.5)
-    assert ranked[0].pairings == []
-    assert ranked[0].score == pytest.approx(1.0)
+    assert ranked[0].soft_breakdown["award_rate"] == pytest.approx(0.25)
+    assert ranked[0].soft_breakdown["layovers"] == pytest.approx(0.25)
+    assert ranked[0].pairings == ["X"]
+    assert ranked[0].score == pytest.approx((0.25 + 0.25) * 1.02)


### PR DESCRIPTION
## Summary
- expand optimizer to support eight scoring categories and default `K=50`
- return pairing identifiers with each candidate
- add tests for persona weighting, seniority adjustment, factor breakdown, and rationale generation

## Testing
- `pytest fastapi_tests/test_optimizer.py fastapi_tests/test_rank_candidates.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2168fd56883328ba57522e89f37ab