### PR TITLE
feat: add landing page variants and switchable home

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ EXPORT_DIR=exports
 
 # Dev server port
 PORT=8000
+
+# Landing page variant to use on the home route
+NEXT_PUBLIC_LANDING=v1

--- a/components/HeroV2.tsx
+++ b/components/HeroV2.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import styles from '../styles/landing.module.css';
+import { track } from '../lib/analytics';
+import LeadForm from './LeadForm';
+
+const HeroV2 = () => {
+  const [showVideo, setShowVideo] = useState(false);
+
+  const openDemo = () => {
+    setShowVideo(true);
+    track('demo_open');
+  };
+
+  return (
+    <section className={styles.hero}>
+      <div className={styles.container}>
+        <h1>Win the schedule you want with AI precision</h1>
+        <p>VectorBid reads your contract and preferences to build PBS bids that maximise time at home.</p>
+        <div className={styles.formRow}>
+          <a href="/signup" className={styles.btnPrimary} onClick={() => track('hero_cta_click')}>Get started free</a>
+          <button onClick={openDemo} className={styles.btnSecondary}>Watch demo</button>
+        </div>
+        <div className={styles.badges}>
+          <span className={styles.badge}>Contract & FAR aware</span>
+          <span className={styles.badge}>Instant export</span>
+          <span className={styles.badge}>Private & secure</span>
+        </div>
+        <LeadForm />
+        {showVideo && (
+          <div role="dialog" aria-modal="true" className={styles.section}>
+            <button onClick={() => setShowVideo(false)} className={styles.btnSecondary}>Close</button>
+            <div style={{ marginTop: '1rem' }}>
+              <iframe
+                width="560"
+                height="315"
+                src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+                title="Demo video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default HeroV2;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,76 +1,13 @@
-import Head from 'next/head';
-import { useEffect, useState } from 'react';
-import Hero from '../components/Hero';
-import Logos from '../components/Logos';
-import Benefits from '../components/Benefits';
-import HowItWorks from '../components/HowItWorks';
-import ROISection from '../components/ROISection';
-import Testimonials from '../components/Testimonials';
-import Pricing from '../components/Pricing';
-import FAQ, { FAQItem } from '../components/FAQ';
-import CTA from '../components/CTA';
-import Footer from '../components/Footer';
-import { initAnalytics } from '../lib/analytics';
-import { hasConsent, giveConsent } from '../lib/consent';
-import styles from '../styles/landing.module.css';
+import type { NextPage } from 'next';
+import V1 from './landing/v1';
+import V2 from './landing/v2';
 
-const faqItems: FAQItem[] = [
-  { q: 'Is VectorBid aware of PBS 2.0?', a: 'Yes. Our logic understands PBS 2.0 rules and formats.' },
-  { q: 'Which airlines do you support?', a: 'We are starting with United and adding more carriers soon.' },
-  { q: 'How accurate are the suggestions?', a: 'We follow your contract and FARs but final responsibility lies with the pilot.' },
-  { q: 'Do you store my data?', a: 'Preferences are stored securely and never shared.' },
-  { q: 'Is there a refund policy?', a: 'We offer a no-questions-asked refund within 30 days.' },
-  { q: 'Are you affiliated with any airline or PBS vendor?', a: 'No. VectorBid is an independent tool and not endorsed by any airline or PBS vendor.' },
-  { q: 'How do I get support?', a: 'Email us anytime at support@vectorbid.com.' },
-  { q: 'What about data privacy?', a: 'Your data stays with us and is used only to improve your bids.' },
-];
-
-const faqJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: faqItems.map((f) => ({
-    '@type': 'Question',
-    name: f.q,
-    acceptedAnswer: { '@type': 'Answer', text: f.a },
-  })),
+const variants: Record<string, NextPage> = {
+  v1: V1,
+  v2: V2,
 };
 
-export default function Home() {
-  const [consent, setConsent] = useState(false);
+const current = process.env.NEXT_PUBLIC_LANDING || 'v1';
+const LandingPage = variants[current] || V1;
 
-  useEffect(() => {
-    initAnalytics();
-    setConsent(hasConsent());
-  }, []);
-
-  return (
-    <>
-      <Head>
-        <title>VectorBid — AI Pilot Bidding Assistant for PBS</title>
-        <meta name="description" content="Turn your preferences into optimized PBS layers in minutes. Contract and FAR-aware suggestions, personas, and instant exports." />
-        <meta property="og:title" content="VectorBid — AI Pilot Bidding Assistant for PBS" />
-        <meta property="og:description" content="Turn your preferences into optimized PBS layers in minutes." />
-        <meta property="og:image" content="/og-vectorbid.svg" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content="/og-vectorbid.svg" />
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
-      </Head>
-      <Hero />
-      <Logos />
-      <Benefits />
-      <HowItWorks />
-      <ROISection />
-      <Testimonials />
-      <Pricing />
-      <FAQ items={faqItems} />
-      <CTA />
-      <Footer />
-      {process.env.NEXT_PUBLIC_ANALYTICS === '1' && !consent && (
-        <div className={styles.consent}>
-          <p>This site uses cookies for analytics.</p>
-          <button className={styles.btnPrimary} onClick={() => { giveConsent(); setConsent(true); }}>OK</button>
-        </div>
-      )}
-    </>
-  );
-}
+export default LandingPage;

--- a/pages/landing/v1.tsx
+++ b/pages/landing/v1.tsx
@@ -1,0 +1,76 @@
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
+import Hero from '../../components/Hero';
+import Logos from '../../components/Logos';
+import Benefits from '../../components/Benefits';
+import HowItWorks from '../../components/HowItWorks';
+import ROISection from '../../components/ROISection';
+import Testimonials from '../../components/Testimonials';
+import Pricing from '../../components/Pricing';
+import FAQ, { FAQItem } from '../../components/FAQ';
+import CTA from '../../components/CTA';
+import Footer from '../../components/Footer';
+import { initAnalytics } from '../../lib/analytics';
+import { hasConsent, giveConsent } from '../../lib/consent';
+import styles from '../../styles/landing.module.css';
+
+const faqItems: FAQItem[] = [
+  { q: 'Is VectorBid aware of PBS 2.0?', a: 'Yes. Our logic understands PBS 2.0 rules and formats.' },
+  { q: 'Which airlines do you support?', a: 'We are starting with United and adding more carriers soon.' },
+  { q: 'How accurate are the suggestions?', a: 'We follow your contract and FARs but final responsibility lies with the pilot.' },
+  { q: 'Do you store my data?', a: 'Preferences are stored securely and never shared.' },
+  { q: 'Is there a refund policy?', a: 'We offer a no-questions-asked refund within 30 days.' },
+  { q: 'Are you affiliated with any airline or PBS vendor?', a: 'No. VectorBid is an independent tool and not endorsed by any airline or PBS vendor.' },
+  { q: 'How do I get support?', a: 'Email us anytime at support@vectorbid.com.' },
+  { q: 'What about data privacy?', a: 'Your data stays with us and is used only to improve your bids.' },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+export default function Home() {
+  const [consent, setConsent] = useState(false);
+
+  useEffect(() => {
+    initAnalytics();
+    setConsent(hasConsent());
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>VectorBid — AI Pilot Bidding Assistant for PBS</title>
+        <meta name="description" content="Turn your preferences into optimized PBS layers in minutes. Contract and FAR-aware suggestions, personas, and instant exports." />
+        <meta property="og:title" content="VectorBid — AI Pilot Bidding Assistant for PBS" />
+        <meta property="og:description" content="Turn your preferences into optimized PBS layers in minutes." />
+        <meta property="og:image" content="/og-vectorbid.svg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="/og-vectorbid.svg" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      </Head>
+      <Hero />
+      <Logos />
+      <Benefits />
+      <HowItWorks />
+      <ROISection />
+      <Testimonials />
+      <Pricing />
+      <FAQ items={faqItems} />
+      <CTA />
+      <Footer />
+      {process.env.NEXT_PUBLIC_ANALYTICS === '1' && !consent && (
+        <div className={styles.consent}>
+          <p>This site uses cookies for analytics.</p>
+          <button className={styles.btnPrimary} onClick={() => { giveConsent(); setConsent(true); }}>OK</button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/pages/landing/v2.tsx
+++ b/pages/landing/v2.tsx
@@ -1,0 +1,76 @@
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
+import HeroV2 from '../../components/HeroV2';
+import Logos from '../../components/Logos';
+import Benefits from '../../components/Benefits';
+import HowItWorks from '../../components/HowItWorks';
+import ROISection from '../../components/ROISection';
+import Testimonials from '../../components/Testimonials';
+import Pricing from '../../components/Pricing';
+import FAQ, { FAQItem } from '../../components/FAQ';
+import CTA from '../../components/CTA';
+import Footer from '../../components/Footer';
+import { initAnalytics } from '../../lib/analytics';
+import { hasConsent, giveConsent } from '../../lib/consent';
+import styles from '../../styles/landing.module.css';
+
+const faqItems: FAQItem[] = [
+  { q: 'Is VectorBid aware of PBS 2.0?', a: 'Yes. Our logic understands PBS 2.0 rules and formats.' },
+  { q: 'Which airlines do you support?', a: 'We are starting with United and adding more carriers soon.' },
+  { q: 'How accurate are the suggestions?', a: 'We follow your contract and FARs but final responsibility lies with the pilot.' },
+  { q: 'Do you store my data?', a: 'Preferences are stored securely and never shared.' },
+  { q: 'Is there a refund policy?', a: 'We offer a no-questions-asked refund within 30 days.' },
+  { q: 'Are you affiliated with any airline or PBS vendor?', a: 'No. VectorBid is an independent tool and not endorsed by any airline or PBS vendor.' },
+  { q: 'How do I get support?', a: 'Email us anytime at support@vectorbid.com.' },
+  { q: 'What about data privacy?', a: 'Your data stays with us and is used only to improve your bids.' },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+export default function LandingV2() {
+  const [consent, setConsent] = useState(false);
+
+  useEffect(() => {
+    initAnalytics();
+    setConsent(hasConsent());
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>VectorBid — Smarter PBS bids with AI</title>
+        <meta name="description" content="Precision PBS bidding with AI-driven contract and FAR awareness." />
+        <meta property="og:title" content="VectorBid — Smarter PBS bids with AI" />
+        <meta property="og:description" content="Let VectorBid craft bids that maximise time at home." />
+        <meta property="og:image" content="/og-vectorbid.svg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="/og-vectorbid.svg" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      </Head>
+      <HeroV2 />
+      <Logos />
+      <ROISection />
+      <Benefits />
+      <HowItWorks />
+      <Testimonials />
+      <Pricing />
+      <FAQ items={faqItems} />
+      <CTA />
+      <Footer />
+      {process.env.NEXT_PUBLIC_ANALYTICS === '1' && !consent && (
+        <div className={styles.consent}>
+          <p>This site uses cookies for analytics.</p>
+          <button className={styles.btnPrimary} onClick={() => { giveConsent(); setConsent(true); }}>OK</button>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- move existing landing page into a dedicated folder and add world-class variant
- allow choosing home page via NEXT_PUBLIC_LANDING env
- document env variable for switching landing pages

## Testing
- `pre-commit run --files pages/index.tsx pages/landing/v1.tsx pages/landing/v2.tsx components/HeroV2.tsx .env.example`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3da0191f08332bf2a90ebdd657ba8