### PR TITLE
Map settings pages to database models

### DIFF
--- a/components/SettingsLayout.tsx
+++ b/components/SettingsLayout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import SettingsNav from './SettingsNav';
+import styles from '../styles/settings.module.css';
+
+type Props = {
+  children: ReactNode;
+};
+
+const SettingsLayout = ({ children }: Props) => (
+  <div className={styles.settingsContainer}>
+    <SettingsNav />
+    <main className={styles.settingsContent}>{children}</main>
+  </div>
+);
+
+export default SettingsLayout;

--- a/components/SettingsNav.tsx
+++ b/components/SettingsNav.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import styles from '../styles/settings.module.css';
+
+const SettingsNav = () => (
+  <nav className={styles.settingsNav}>
+    <ul>
+      <li><Link href="/settings/security">Security</Link></li>
+      <li><Link href="/settings/communication">Communication Preferences</Link></li>
+      <li><Link href="/settings/career">Career Preferences</Link></li>
+      <li><Link href="/settings/subscription">Subscription Info</Link></li>
+      <li><Link href="/settings/billing">Billing History</Link></li>
+    </ul>
+  </nav>
+);
+
+export default SettingsNav;

--- a/pages/settings/billing.tsx
+++ b/pages/settings/billing.tsx
@@ -1,0 +1,23 @@
+import SettingsLayout from '../../components/SettingsLayout';
+
+const BillingSettings = () => (
+  <SettingsLayout>
+    <h1>Billing History</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Description</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td colSpan={3}>No billing records found.</td>
+        </tr>
+      </tbody>
+    </table>
+  </SettingsLayout>
+);
+
+export default BillingSettings;

--- a/pages/settings/career.tsx
+++ b/pages/settings/career.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import SettingsLayout from '../../components/SettingsLayout';
+
+const CareerSettings = () => {
+  const [desiredBase, setDesiredBase] = useState('');
+  const [desiredAircraft, setDesiredAircraft] = useState('');
+
+  return (
+    <SettingsLayout>
+      <h1>Career Preferences</h1>
+      <form>
+        <label>
+          Preferred Base
+          <input
+            type="text"
+            value={desiredBase}
+            onChange={(e) => setDesiredBase(e.target.value)}
+          />
+        </label>
+        <br />
+        <label>
+          Desired Aircraft
+          <input
+            type="text"
+            value={desiredAircraft}
+            onChange={(e) => setDesiredAircraft(e.target.value)}
+          />
+        </label>
+      </form>
+    </SettingsLayout>
+  );
+};
+
+export default CareerSettings;

--- a/pages/settings/communication.tsx
+++ b/pages/settings/communication.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import SettingsLayout from '../../components/SettingsLayout';
+
+const CommunicationSettings = () => {
+  const [emailOptIn, setEmailOptIn] = useState(true);
+  const [smsOptIn, setSmsOptIn] = useState(false);
+
+  return (
+    <SettingsLayout>
+      <h1>Communication Preferences</h1>
+      <form>
+        <label>
+          <input
+            type="checkbox"
+            checked={emailOptIn}
+            onChange={(e) => setEmailOptIn(e.target.checked)}
+          />
+          Email notifications
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={smsOptIn}
+            onChange={(e) => setSmsOptIn(e.target.checked)}
+          />
+          SMS notifications
+        </label>
+      </form>
+    </SettingsLayout>
+  );
+};
+
+export default CommunicationSettings;

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -1,0 +1,10 @@
+import SettingsLayout from '../../components/SettingsLayout';
+
+const SettingsIndex = () => (
+  <SettingsLayout>
+    <h1>Profile Settings</h1>
+    <p>Select an option from the menu to manage your account.</p>
+  </SettingsLayout>
+);
+
+export default SettingsIndex;

--- a/pages/settings/security.tsx
+++ b/pages/settings/security.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import SettingsLayout from '../../components/SettingsLayout';
+
+const SecuritySettings = () => {
+  const [twoFactor, setTwoFactor] = useState(false);
+
+  return (
+    <SettingsLayout>
+      <h1>Security Settings</h1>
+      <form>
+        <label>
+          <input
+            type="checkbox"
+            checked={twoFactor}
+            onChange={(e) => setTwoFactor(e.target.checked)}
+          />
+          Enable two-factor authentication
+        </label>
+      </form>
+    </SettingsLayout>
+  );
+};
+
+export default SecuritySettings;

--- a/pages/settings/subscription.tsx
+++ b/pages/settings/subscription.tsx
@@ -1,0 +1,10 @@
+import SettingsLayout from '../../components/SettingsLayout';
+
+const SubscriptionSettings = () => (
+  <SettingsLayout>
+    <h1>Subscription Information</h1>
+    <p>Your current plan and renewal details will appear here.</p>
+  </SettingsLayout>
+);
+
+export default SubscriptionSettings;

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -20,6 +20,19 @@ class User(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     last_active = db.Column(db.DateTime)
 
+    # Relationships to settings models
+    security_settings = db.relationship(
+        "SecuritySettings", back_populates="user", uselist=False
+    )
+    communication_preferences = db.relationship(
+        "CommunicationPreference", back_populates="user", uselist=False
+    )
+    career_preferences = db.relationship(
+        "CareerPreference", back_populates="user", uselist=False
+    )
+    subscriptions = db.relationship("Subscription", back_populates="user")
+    billing_history = db.relationship("BillingRecord", back_populates="user")
+
 
 class BidPacket(db.Model):
     __tablename__ = "bid_packets"
@@ -58,3 +71,59 @@ class AdminActionLog(db.Model):
     admin_id = db.Column(db.String(120))
     action = db.Column(db.String(50), nullable=False)
     target = db.Column(db.String(255))
+
+
+class SecuritySettings(db.Model):
+    __tablename__ = "security_settings"
+
+    user_id = db.Column(db.String, db.ForeignKey("users.id"), primary_key=True)
+    two_factor_enabled = db.Column(db.Boolean, default=False, nullable=False)
+    last_password_change = db.Column(db.DateTime)
+
+    user = db.relationship("User", back_populates="security_settings")
+
+
+class CommunicationPreference(db.Model):
+    __tablename__ = "communication_preferences"
+
+    user_id = db.Column(db.String, db.ForeignKey("users.id"), primary_key=True)
+    email_opt_in = db.Column(db.Boolean, default=True, nullable=False)
+    sms_opt_in = db.Column(db.Boolean, default=False, nullable=False)
+    preferred_language = db.Column(db.String(10))
+
+    user = db.relationship("User", back_populates="communication_preferences")
+
+
+class CareerPreference(db.Model):
+    __tablename__ = "career_preferences"
+
+    user_id = db.Column(db.String, db.ForeignKey("users.id"), primary_key=True)
+    desired_base = db.Column(db.String(50))
+    desired_aircraft = db.Column(db.String(50))
+    long_term_goal = db.Column(db.String(255))
+
+    user = db.relationship("User", back_populates="career_preferences")
+
+
+class Subscription(db.Model):
+    __tablename__ = "subscriptions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String, db.ForeignKey("users.id"), nullable=False)
+    plan = db.Column(db.String(50))
+    status = db.Column(db.String(20))
+    renew_at = db.Column(db.DateTime)
+
+    user = db.relationship("User", back_populates="subscriptions")
+
+
+class BillingRecord(db.Model):
+    __tablename__ = "billing_records"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String, db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Numeric(10, 2))
+    description = db.Column(db.String(255))
+    billed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", back_populates="billing_history")

--- a/styles/settings.module.css
+++ b/styles/settings.module.css
@@ -1,0 +1,31 @@
+.settingsContainer {
+  display: flex;
+  min-height: 100vh;
+}
+
+.settingsNav {
+  width: 220px;
+  padding: 1rem;
+  border-right: 1px solid #e5e5e5;
+  background-color: #fafafa;
+}
+
+.settingsNav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.settingsNav li {
+  margin-bottom: 0.5rem;
+}
+
+.settingsNav a {
+  color: #333;
+  text-decoration: none;
+}
+
+.settingsContent {
+  flex: 1;
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for security, communication, career, subscription and billing settings
- scaffold settings pages with basic forms mirroring these models

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3dfc9fd4083329df4b3d012d56934