### PR TITLE
feat(ui): persona presets + live NLP parse + what-if bar

### DIFF
--- a/components/PersonaSelect.tsx
+++ b/components/PersonaSelect.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface PersonaSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const PERSONAS = [
+  { value: 'family_first', label: 'Family First' },
+  { value: 'money_maker', label: 'Money Maker' },
+  { value: 'commuter_friendly', label: 'Commuter Friendly' },
+];
+
+export default function PersonaSelect({ value, onChange }: PersonaSelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: 4 }}
+    >
+      <option value="">Select persona</option>
+      {PERSONAS.map((p) => (
+        <option key={p.value} value={p.value}>
+          {p.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/PreferencePreview.tsx
+++ b/components/PreferencePreview.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+interface PreferencePreviewProps {
+  persona: string;
+}
+
+export default function PreferencePreview({ persona }: PreferencePreviewProps) {
+  const [text, setText] = useState('');
+  const [json, setJson] = useState<any | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(async () => {
+      if (!text.trim()) {
+        setJson(null);
+        return;
+      }
+      try {
+        const res = await fetch('/api/parse_preview', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text, persona }),
+        });
+        const data = await res.json();
+        setJson(data.preference_schema);
+      } catch (err) {
+        console.error('preview failed', err);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [text, persona]);
+
+  return (
+    <div>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Describe your preferences"
+        style={{ width: '100%', minHeight: '4rem', padding: '0.5rem', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      {json && (
+        <pre style={{ marginTop: '0.5rem', background: '#f5f5f5', padding: '0.5rem', fontSize: '0.8rem', overflowX: 'auto' }}>
+          {JSON.stringify(json, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/components/WhatIfBar.tsx
+++ b/components/WhatIfBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface WhatIfBarProps {
+  weights: Record<string, number>;
+  onChange: (w: Record<string, number>) => void;
+}
+
+export default function WhatIfBar({ weights, onChange }: WhatIfBarProps) {
+  const handle = (key: string, value: number) => {
+    onChange({ ...weights, [key]: value });
+  };
+
+  return (
+    <div>
+      {Object.entries(weights).map(([key, value]) => (
+        <div key={key} style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+          <label style={{ width: '10rem' }}>{key}</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            value={value}
+            onChange={(e) => handle(key, parseFloat(e.target.value))}
+            style={{ flex: 1 }}
+          />
+          <span style={{ marginLeft: '0.5rem', width: '2rem', textAlign: 'right' }}>{value.toFixed(1)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/fastapi_tests/test_parse_preview.py
+++ b/fastapi_tests/test_parse_preview.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_parse_preview_red_eye() -> None:
+    resp = client.post("/api/parse_preview", json={"text": "no red-eye flights"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preference_schema"]["hard_constraints"]["no_red_eyes"] is True

--- a/pages/onboarding.tsx
+++ b/pages/onboarding.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import PersonaSelect from '../components/PersonaSelect';
+import PreferencePreview from '../components/PreferencePreview';
+import WhatIfBar from '../components/WhatIfBar';
+
+export default function Onboarding() {
+  const [persona, setPersona] = useState('');
+  const [weights, setWeights] = useState({
+    weekend_weight: 0.5,
+    credit_weight: 0.5,
+    trip_weight: 0.5,
+  });
+
+  return (
+    <div style={{ maxWidth: '40rem', margin: '0 auto', padding: '1rem' }}>
+      <h1>Onboarding</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <PersonaSelect value={persona} onChange={setPersona} />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <PreferencePreview persona={persona} />
+      </div>
+      <WhatIfBar weights={weights} onChange={setWeights} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add FastAPI `/api/parse_preview` endpoint returning `PreferenceSchema`
- add PersonaSelect, PreferencePreview (debounced), and WhatIfBar components
- cover preview endpoint with test and simple onboarding page

## Testing
- `SKIP=mypy pre-commit run --files app/api/routes.py fastapi_tests/test_parse_preview.py components/PersonaSelect.tsx components/PreferencePreview.tsx components/WhatIfBar.tsx pages/onboarding.tsx`
- `pytest -q` *(fails: KeyError: 'candidates'; AssertionError in meta tests)*
- `pytest fastapi_tests/test_parse_preview.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3eef9f22c8332bef73d733b4dc1b2