### PR TITLE
feat(pbs): detect shadowing + unreachable filters + export signing

### DIFF
--- a/app/pbs/export.py
+++ b/app/pbs/export.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from app.models import BidLayerArtifact
+
+ArtifactLike = BidLayerArtifact | Mapping[str, Any]
+
+
+def _to_plain_dict(artifact: ArtifactLike) -> dict[str, Any]:
+    if isinstance(artifact, BidLayerArtifact):
+        return cast(dict[str, Any], artifact.model_dump())
+    return cast(dict[str, Any], dict(artifact))
+
+
+def _canonical_json(data: Mapping[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def append_hash(artifact: ArtifactLike) -> dict:
+    core = _to_plain_dict(artifact)
+    canonical = _canonical_json(core)
+    export_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    core["export_hash"] = export_hash
+    return core
+
+
+def write_json(artifact: ArtifactLike, path: Path) -> Path:
+    data = append_hash(artifact)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=True)
+    return path

--- a/app/pbs/lint.py
+++ b/app/pbs/lint.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from app.models import BidLayerArtifact
+
+ArtifactLike = BidLayerArtifact | dict[str, Any]
+
+
+def _to_plain_dict(artifact: ArtifactLike) -> dict[str, Any]:
+    if isinstance(artifact, BidLayerArtifact):
+        return cast(dict[str, Any], artifact.model_dump())
+    return cast(dict[str, Any], dict(artifact))
+
+
+def lint_shadowing(artifact: ArtifactLike) -> list[str]:
+    data = _to_plain_dict(artifact)
+    warnings: list[str] = []
+    seen: list[tuple] = []
+    layers = data.get("layers") or []
+    for layer in layers:
+        n = layer.get("n")
+        key = tuple(
+            sorted(
+                (
+                    f.get("type"),
+                    f.get("op"),
+                    tuple(f.get("values", [])),
+                )
+                for f in layer.get("filters", [])
+            )
+        )
+        if key in seen:
+            warnings.append(f"layer {n}: shadowed by previous layer")
+        else:
+            seen.append(key)
+    return warnings
+
+
+def lint_unreachable(artifact: ArtifactLike) -> list[str]:
+    data = _to_plain_dict(artifact)
+    warnings: list[str] = []
+    layers = data.get("layers") or []
+    for layer in layers:
+        n = layer.get("n")
+        for f in layer.get("filters", []) or []:
+            op = str(f.get("op", "")).upper()
+            values = f.get("values") or []
+            if op in {"IN", "EQUALS", "=="} and not values:
+                warnings.append(f"layer {n}: {f.get('type')} has no values")
+            if op in {"IN", "EQUALS", "=="} and len(values) != len(set(values)):
+                warnings.append(f"layer {n}: {f.get('type')} has redundant equals")
+    return warnings
+
+
+def lint_artifact(artifact: ArtifactLike) -> dict[str, list[str]]:
+    warnings: list[str] = []
+    warnings.extend(lint_shadowing(artifact))
+    warnings.extend(lint_unreachable(artifact))
+    return {"errors": [], "warnings": warnings}
+
+
+# Back-compat alias
+lint_layers = lint_artifact

--- a/tests/test_pbs_export.py
+++ b/tests/test_pbs_export.py
@@ -1,0 +1,26 @@
+import hashlib
+import json
+from pathlib import Path
+
+from app.pbs.export import append_hash, write_json
+
+
+def test_append_hash(tmp_path: Path) -> None:
+    artifact = {
+        "airline": "UAL",
+        "format": "PBS2",
+        "month": "2025-09",
+        "layers": [],
+        "lint": {},
+    }
+    data = append_hash(artifact)
+    canonical = json.dumps(
+        artifact, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    assert data["export_hash"] == expected
+
+    out_file = tmp_path / "artifact.json"
+    write_json(artifact, out_file)
+    saved = json.loads(out_file.read_text())
+    assert saved["export_hash"] == expected

--- a/tests/test_pbs_lint.py
+++ b/tests/test_pbs_lint.py
@@ -1,0 +1,40 @@
+from app.pbs.lint import lint_artifact
+
+
+def test_lint_shadowing() -> None:
+    artifact = {
+        "layers": [
+            {
+                "n": 1,
+                "filters": [{"type": "PairingId", "op": "IN", "values": ["A"]}],
+                "prefer": "YES",
+            },
+            {
+                "n": 2,
+                "filters": [{"type": "PairingId", "op": "IN", "values": ["A"]}],
+                "prefer": "YES",
+            },
+        ]
+    }
+    result = lint_artifact(artifact)
+    assert any("layer 2" in w and "shadowed" in w for w in result["warnings"])
+
+
+def test_lint_unreachable() -> None:
+    artifact = {
+        "layers": [
+            {
+                "n": 1,
+                "filters": [{"type": "PairingId", "op": "IN", "values": []}],
+                "prefer": "YES",
+            },
+            {
+                "n": 2,
+                "filters": [{"type": "PairingId", "op": "IN", "values": ["A", "A"]}],
+                "prefer": "YES",
+            },
+        ]
+    }
+    result = lint_artifact(artifact)
+    assert any("layer 1" in w and "no values" in w for w in result["warnings"])
+    assert any("layer 2" in w and "redundant equals" in w for w in result["warnings"])


### PR DESCRIPTION
## Summary
- add PBS linter checks for shadowed layers and unreachable filters
- sign PBS exports by appending SHA256 hash of canonical JSON
- test warnings and export signing

## Testing
- `pre-commit run --files app/pbs/lint.py app/pbs/export.py tests/test_pbs_lint.py tests/test_pbs_export.py`
- `pytest tests/test_pbs_lint.py tests/test_pbs_export.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3eee7c75483329e51d2db1e8d5cbd