### PR TITLE
feat(rules): UAL YAML v2025.09 + legality validator

### DIFF
--- a/app/legality/__init__.py
+++ b/app/legality/__init__.py
@@ -1,0 +1,5 @@
+"""Legality validation utilities."""
+
+from .validate import ValidationReport, validate
+
+__all__ = ["ValidationReport", "validate"]

--- a/app/legality/validate.py
+++ b/app/legality/validate.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field
+
+
+class Rule(BaseModel):
+    id: str
+    desc: str
+    clause: str
+    severity: str
+    evaluate: str
+
+
+class RuleHit(BaseModel):
+    id: str
+    desc: str
+    clause: str
+    severity: str
+    trip_id: str | None = None
+
+
+class ValidationReport(BaseModel):
+    valid_trips: list[dict[str, Any]] = Field(default_factory=list)
+    rule_hits: list[RuleHit] = Field(default_factory=list)
+
+
+def _load_rules() -> list[Rule]:
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "rule_packs" / "UAL" / "2025.09.yml"
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return [Rule.model_validate(r) for r in data.get("rules", [])]
+
+
+_RULES = _load_rules()
+
+
+def validate(trips: list[dict[str, Any]], context: dict[str, Any]) -> ValidationReport:
+    """Validate trips against hard legality rules.
+
+    Trips with hard rule hits are excluded from the returned ``valid_trips``.
+    ``rule_hits`` include clause references for downstream reporting.
+    """
+
+    rule_hits: list[RuleHit] = []
+    valid_trips: list[dict[str, Any]] = []
+
+    for trip in trips:
+        trip_hits: list[RuleHit] = []
+        for rule in _RULES:
+            if "trip" in rule.evaluate:
+                env = {"trip": trip, "context": context}
+                ok = bool(eval(rule.evaluate, {}, env))  # noqa: S307
+                if not ok:
+                    hit = RuleHit(
+                        id=rule.id,
+                        desc=rule.desc,
+                        clause=rule.clause,
+                        severity=rule.severity,
+                        trip_id=trip.get("id"),
+                    )
+                    rule_hits.append(hit)
+                    trip_hits.append(hit)
+        if not any(h.severity == "hard" for h in trip_hits):
+            valid_trips.append(trip)
+
+    for rule in _RULES:
+        if "trip" not in rule.evaluate:
+            env = {"context": context}
+            ok = bool(eval(rule.evaluate, {}, env))  # noqa: S307
+            if not ok:
+                rule_hits.append(
+                    RuleHit(
+                        id=rule.id,
+                        desc=rule.desc,
+                        clause=rule.clause,
+                        severity=rule.severity,
+                        trip_id=None,
+                    )
+                )
+
+    return ValidationReport(valid_trips=valid_trips, rule_hits=rule_hits)

--- a/rule_packs/UAL/2025.09.yml
+++ b/rule_packs/UAL/2025.09.yml
@@ -1,0 +1,29 @@
+version: '2025.09'
+airline: UAL
+id: UAL-2025-09
+rules:
+  - id: MIN_DAYS_OFF
+    desc: Minimum 8 days off per month
+    clause: UPA 5.a
+    severity: hard
+    evaluate: "context.get('days_off', 0) >= 8"
+  - id: MAX_DUTY_HOURS
+    desc: Duty time may not exceed max duty hours
+    clause: UPA 6.b
+    severity: hard
+    evaluate: "trip.get('duty_hours', 0) <= context.get('max_duty_hours', 12)"
+  - id: MAX_FLIGHT_TIME
+    desc: Flight time may not exceed max flight time
+    clause: UPA 6.c
+    severity: hard
+    evaluate: "trip.get('flight_time', 0) <= context.get('max_flight_time', 8)"
+  - id: MIN_REST_HOURS
+    desc: Rest period must be at least min rest hours
+    clause: UPA 7.a
+    severity: hard
+    evaluate: "trip.get('rest_hours', 0) >= context.get('min_rest_hours', 10)"
+  - id: MIN_BREAK_MINUTES
+    desc: Break must be at least 30 minutes
+    clause: UPA 7.b
+    severity: hard
+    evaluate: "trip.get('break_minutes', 0) >= 30"

--- a/tests/test_legality_validate.py
+++ b/tests/test_legality_validate.py
@@ -1,0 +1,133 @@
+from app.legality import validate
+
+
+def test_min_days_off_rule() -> None:
+    trips: list[dict] = []
+    context_ok = {"days_off": 10}
+    report_ok = validate(trips, context_ok)
+    assert not any(hit.id == "MIN_DAYS_OFF" for hit in report_ok.rule_hits)
+
+    context_bad = {"days_off": 4}
+    report_bad = validate(trips, context_bad)
+    assert any(hit.id == "MIN_DAYS_OFF" for hit in report_bad.rule_hits)
+
+
+def test_max_duty_hours_rule() -> None:
+    trips = [
+        {
+            "id": "T1",
+            "duty_hours": 10,
+            "flight_time": 5,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+        {
+            "id": "T2",
+            "duty_hours": 13,
+            "flight_time": 5,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+    ]
+    context = {
+        "max_duty_hours": 12,
+        "max_flight_time": 8,
+        "min_rest_hours": 10,
+        "days_off": 10,
+    }
+    report = validate(trips, context)
+    assert {t["id"] for t in report.valid_trips} == {"T1"}
+    assert any(
+        hit.id == "MAX_DUTY_HOURS" and hit.trip_id == "T2" for hit in report.rule_hits
+    )
+
+
+def test_max_flight_time_rule() -> None:
+    trips = [
+        {
+            "id": "T1",
+            "duty_hours": 10,
+            "flight_time": 7,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+        {
+            "id": "T2",
+            "duty_hours": 10,
+            "flight_time": 9,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+    ]
+    context = {
+        "max_duty_hours": 12,
+        "max_flight_time": 8,
+        "min_rest_hours": 10,
+        "days_off": 10,
+    }
+    report = validate(trips, context)
+    assert {t["id"] for t in report.valid_trips} == {"T1"}
+    assert any(
+        hit.id == "MAX_FLIGHT_TIME" and hit.trip_id == "T2" for hit in report.rule_hits
+    )
+
+
+def test_min_rest_hours_rule() -> None:
+    trips = [
+        {
+            "id": "T1",
+            "duty_hours": 10,
+            "flight_time": 5,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+        {
+            "id": "T2",
+            "duty_hours": 10,
+            "flight_time": 5,
+            "rest_hours": 8,
+            "break_minutes": 40,
+        },
+    ]
+    context = {
+        "max_duty_hours": 12,
+        "max_flight_time": 8,
+        "min_rest_hours": 10,
+        "days_off": 10,
+    }
+    report = validate(trips, context)
+    assert {t["id"] for t in report.valid_trips} == {"T1"}
+    assert any(
+        hit.id == "MIN_REST_HOURS" and hit.trip_id == "T2" for hit in report.rule_hits
+    )
+
+
+def test_min_break_minutes_rule() -> None:
+    trips = [
+        {
+            "id": "T1",
+            "duty_hours": 10,
+            "flight_time": 5,
+            "rest_hours": 11,
+            "break_minutes": 40,
+        },
+        {
+            "id": "T2",
+            "duty_hours": 10,
+            "flight_time": 5,
+            "rest_hours": 11,
+            "break_minutes": 20,
+        },
+    ]
+    context = {
+        "max_duty_hours": 12,
+        "max_flight_time": 8,
+        "min_rest_hours": 10,
+        "days_off": 10,
+    }
+    report = validate(trips, context)
+    assert {t["id"] for t in report.valid_trips} == {"T1"}
+    assert any(
+        hit.id == "MIN_BREAK_MINUTES" and hit.trip_id == "T2"
+        for hit in report.rule_hits
+    )


### PR DESCRIPTION
## Summary
- add UAL 2025.09 rule pack capturing min days off, duty, flight time, rest, and break clauses
- implement legality validator that loads rules and reports clause-referenced hits while filtering out hard violations
- test validator across all new rules with passing and failing trip scenarios

## Testing
- `pre-commit run --files rule_packs/UAL/2025.09.yml app/legality/__init__.py app/legality/validate.py tests/test_legality_validate.py`
- `pytest tests/test_legality_validate.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3eecff2b883329c141365638f5f8e