### PR TITLE
Export audit + signature

### DIFF
--- a/app/export/audit.py
+++ b/app/export/audit.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _db_path() -> Path:
+    base = os.environ.get("EXPORT_DB_PATH")
+    if base:
+        return Path(base)
+    export_dir = Path(os.environ.get("EXPORT_DIR", Path.cwd() / "exports"))
+    return export_dir / "exports.db"
+
+
+def insert_record(export_id: str, ctx_id: str, path: Path, sha256: str) -> None:
+    """Insert a row into the exports audit table."""
+    dbp = _db_path()
+    dbp.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(dbp)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS exports ("
+            "id TEXT PRIMARY KEY,"
+            "ctx_id TEXT,"
+            "path TEXT,"
+            "sha256 TEXT,"
+            "created_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO exports (id, ctx_id, path, sha256, created_at) VALUES (?, ?, ?, ?, ?)",
+            (export_id, ctx_id, str(path), sha256, datetime.utcnow().isoformat()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_record(export_id: str) -> dict[str, Any] | None:
+    dbp = _db_path()
+    if not dbp.exists():
+        return None
+    conn = sqlite3.connect(dbp)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(
+            "SELECT id, ctx_id, path, sha256, created_at FROM exports WHERE id = ?",
+            (export_id,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()

--- a/app/logging_utils.py
+++ b/app/logging_utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 from typing import Any
@@ -25,3 +26,10 @@ def install_pii_filter() -> None:
         return record
 
     logging.setLogRecordFactory(factory)
+
+
+def log_event(event: str, **data: Any) -> None:
+    """Emit a structured log event."""
+    logging.getLogger("vectorbid.events").info(
+        "%s %s", event, json.dumps(data, sort_keys=True)
+    )


### PR DESCRIPTION
## Summary
- compute SHA-256 for exports and write companion .sig file
- record each export in a SQLite audit table with ctx and path metadata
- expose metadata and download endpoints for stored exports

## Testing
- `pre-commit run --files app/logging_utils.py app/api/routes.py app/export/audit.py fastapi_tests/test_export_auth.py fastapi_tests/test_export_audit.py` (fails: mypy missing types)
- `pytest fastapi_tests/test_export_auth.py fastapi_tests/test_export_audit.py`

------
https://chatgpt.com/codex/tasks/task_e_68a40366da6c8332bd2b1138c1089463