### PR TITLE
feat: add rulepack validator and tests

### DIFF
--- a/.github/workflows/rulepack.yml
+++ b/.github/workflows/rulepack.yml
@@ -1,0 +1,22 @@
+name: rulepack
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]' || pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Validate rulepacks
+        run: python tools/rulepack_validate.py rule_packs/**/*.yml

--- a/app/rules/schema.json
+++ b/app/rules/schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["version", "airline", "id", "rules"],
+  "properties": {
+    "version": {"type": "string"},
+    "airline": {"type": "string"},
+    "id": {"type": "string"},
+    "far117": {"$ref": "#/$defs/rule_group"},
+    "union": {"$ref": "#/$defs/rule_group"},
+    "rules": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/rule"}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "rule_group": {
+      "type": "object",
+      "properties": {
+        "min_rest_hours": {"type": "number"},
+        "max_duty_hours_per_day": {"type": "number"},
+        "hard": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/rule"}
+        },
+        "soft": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/soft_rule"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "rule": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {"type": "string"},
+        "check": {"type": "string"},
+        "when": {"type": ["string", "boolean"]},
+        "desc": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "soft_rule": {
+      "type": "object",
+      "required": ["id", "score"],
+      "properties": {
+        "id": {"type": "string"},
+        "score": {"type": "string"},
+        "weight": {"type": ["number", "string"]},
+        "desc": {"type": "string"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ uvicorn>=0.29
 fastapi>=0.110
 pydantic>=2
 starlette>=0.37
+jsonschema>=4,<5

--- a/tests/fixtures/rulepacks/duplicate_id.yml
+++ b/tests/fixtures/rulepacks/duplicate_id.yml
@@ -1,0 +1,8 @@
+version: '1'
+airline: TEST
+id: TEST-1
+rules:
+  - id: R1
+    check: a
+  - id: R1
+    check: b

--- a/tests/fixtures/rulepacks/missing_version.yml
+++ b/tests/fixtures/rulepacks/missing_version.yml
@@ -1,0 +1,3 @@
+airline: TEST
+id: TEST-1
+rules: []

--- a/tests/fixtures/rulepacks/unknown_field.yml
+++ b/tests/fixtures/rulepacks/unknown_field.yml
@@ -1,0 +1,5 @@
+version: '1'
+airline: TEST
+id: TEST-1
+unknown: true
+rules: []

--- a/tests/fixtures/rulepacks/valid.yml
+++ b/tests/fixtures/rulepacks/valid.yml
@@ -1,0 +1,11 @@
+version: '1'
+airline: TEST
+id: TEST-1
+far117:
+  hard:
+    - id: H1
+      check: x > 1
+  soft:
+    - id: S1
+      score: '1'
+rules: []

--- a/tests/test_rulepack_validate.py
+++ b/tests/test_rulepack_validate.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from tools.rulepack_validate import load_schema, validate_file
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rulepacks"
+SCHEMA = load_schema()
+
+
+def path(name: str) -> Path:
+    return FIXTURES / name
+
+
+def test_valid_rulepack() -> None:
+    assert not validate_file(path("valid.yml"), SCHEMA)
+
+
+def test_unknown_field() -> None:
+    errors = validate_file(path("unknown_field.yml"), SCHEMA)
+    assert any("additional properties" in e.lower() for e in errors)
+
+
+def test_duplicate_ids() -> None:
+    errors = validate_file(path("duplicate_id.yml"), SCHEMA)
+    assert any("duplicate" in e for e in errors)
+
+
+def test_missing_version() -> None:
+    errors = validate_file(path("missing_version.yml"), SCHEMA)
+    assert any("version" in e for e in errors)

--- a/tools/rulepack_validate.py
+++ b/tools/rulepack_validate.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, cast
+
+import yaml  # type: ignore[import-untyped]
+from jsonschema import Draft7Validator
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "app" / "rules" / "schema.json"
+
+
+def load_schema() -> dict[str, Any]:
+    with SCHEMA_PATH.open() as f:
+        return cast(dict[str, Any], json.load(f))
+
+
+def _collect_ids(obj: Any) -> list[str]:
+    ids: list[str] = []
+    if isinstance(obj, dict):
+        maybe_id = obj.get("id")
+        if isinstance(maybe_id, str):
+            ids.append(maybe_id)
+        for value in obj.values():
+            ids.extend(_collect_ids(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            ids.extend(_collect_ids(item))
+    return ids
+
+
+def validate_data(data: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+    validator = Draft7Validator(schema)
+    errors = [e.message for e in validator.iter_errors(data)]
+    ids = _collect_ids(data)
+    duplicates = [i for i, count in Counter(ids).items() if count > 1]
+    if duplicates:
+        errors.append(f"duplicate ids: {', '.join(sorted(duplicates))}")
+    return errors
+
+
+def validate_file(path: Path, schema: dict[str, Any] | None = None) -> list[str]:
+    if schema is None:
+        schema = load_schema()
+    with path.open() as f:
+        data = yaml.safe_load(f)
+    return validate_data(data, schema)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate rulepack YAML files")
+    parser.add_argument("paths", nargs="+", help="Glob paths to rulepack files")
+    args = parser.parse_args(argv)
+
+    schema = load_schema()
+    errors_found = False
+    for pattern in args.paths:
+        for filename in sorted(glob.glob(pattern)):
+            path = Path(filename)
+            errors = validate_file(path, schema)
+            if errors:
+                errors_found = True
+                for err in errors:
+                    print(f"{path}: {err}", file=sys.stderr)
+    return 1 if errors_found else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add JSON schema and CLI validator for rulepacks
- test rulepack validation against valid and invalid fixtures
- run rulepack validator in CI

## Testing
- `pre-commit run --files .github/workflows/rulepack.yml app/rules/schema.json requirements-dev.txt tools/rulepack_validate.py tests/test_rulepack_validate.py tests/fixtures/rulepacks/valid.yml tests/fixtures/rulepacks/unknown_field.yml tests/fixtures/rulepacks/duplicate_id.yml tests/fixtures/rulepacks/missing_version.yml`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rulepack_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4035f779c8332933976c48fcfb7b6