### PR TITLE
feat: add FAQ API and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Docs live in `docs/`:
 - GIT_WORKFLOW.md, RULE_PACKS.md, LEGACY.md
 
 _Last updated: 2025-08-18_
+
+### FAQ
+
+- `GET /faq` serves static FAQ entries from `app/content/faq.en.json`.
+- Optional `?query=` filters results by question or answer text.
+- Frontend available at `/faq` with search and anchors.

--- a/app/content/faq.en.json
+++ b/app/content/faq.en.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "bidding",
+    "question": "How does VectorBid choose bids?",
+    "answer": "VectorBid uses your preferences to generate optimal bid layers.",
+    "rationale": "https://www.law.cornell.edu/cfr/text/14/117"
+  },
+  {
+    "id": "data",
+    "question": "Do you store my data?",
+    "answer": "Preferences are stored securely and never shared.",
+    "rationale": "https://example.com/privacy"
+  },
+  {
+    "id": "refund",
+    "question": "Is there a refund policy?",
+    "answer": "We offer a no-questions-asked refund within 30 days.",
+    "rationale": "https://example.com/refund-policy"
+  }
+]

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.models import (
     PreferenceSchema,
     StrategyDirectives,
 )
+from app.routes.faq import router as faq_router
 from app.routes.meta import router as meta_router
 from app.routes.ops import router as ops_router
 from app.routes.ui import router as ui_router
@@ -78,6 +79,7 @@ app.include_router(api_router, tags=["API"])
 app.include_router(meta_router, tags=["Meta"])
 app.include_router(ops_router, tags=["Ops"])
 app.include_router(ui_router, tags=["UI"])
+app.include_router(faq_router, tags=["FAQ"])
 
 # Legacy compatibility
 app.include_router(compat_validate_router)

--- a/app/models.py
+++ b/app/models.py
@@ -89,3 +89,12 @@ class BidLayerArtifact(BaseModel):
     layers: list[Layer]
     lint: dict[str, list[str]]
     export_hash: str
+
+
+class FAQItem(BaseModel):
+    """FAQ entry served by `/faq`"""
+
+    id: str
+    question: str
+    answer: str
+    rationale: str | None = None

--- a/app/routes/faq.py
+++ b/app/routes/faq.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from app.models import FAQItem
+
+router = APIRouter()
+
+FAQ_PATH = Path(__file__).resolve().parent.parent / "content" / "faq.en.json"
+with FAQ_PATH.open("r", encoding="utf-8") as f:
+    _FAQ_ITEMS: list[FAQItem] = [FAQItem(**item) for item in json.load(f)]
+
+
+@router.get("/faq", response_model=list[FAQItem])
+def get_faq(query: str | None = None) -> list[FAQItem]:
+    items = _FAQ_ITEMS
+    if query:
+        q = query.lower()
+        items = [
+            item
+            for item in _FAQ_ITEMS
+            if q in item.question.lower() or q in item.answer.lower()
+        ]
+    return items

--- a/fastapi_tests/test_faq.py
+++ b/fastapi_tests/test_faq.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.models import FAQItem
+from app.routes.faq import router as faq_router
+
+app = FastAPI()
+app.include_router(faq_router)
+client = TestClient(app)
+
+
+def test_faq_model_validation() -> None:
+    item = FAQItem(id="x", question="q", answer="a")
+    assert item.model_dump()["id"] == "x"
+    with pytest.raises(ValidationError):
+        FAQItem(question="q", answer="a")
+
+
+def test_faq_no_query_returns_all() -> None:
+    resp = client.get("/faq")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+
+
+def test_faq_query_filters() -> None:
+    resp = client.get("/faq", params={"query": "VectorBid"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["id"] == "bidding"

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+interface FAQItem {
+  id: string;
+  question: string;
+  answer: string;
+  rationale?: string | null;
+}
+
+export default function FAQPage() {
+  const [items, setItems] = useState<FAQItem[]>([]);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    fetch('/faq')
+      .then((res) => res.json())
+      .then((data) => setItems(data));
+  }, []);
+
+  const filtered = query
+    ? items.filter(
+        (i) =>
+          i.question.toLowerCase().includes(query.toLowerCase()) ||
+          i.answer.toLowerCase().includes(query.toLowerCase())
+      )
+    : items;
+
+  return (
+    <div>
+      <h1>FAQ</h1>
+      <input
+        type="search"
+        placeholder="Search FAQ"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <ul>
+        {filtered.map((item) => (
+          <li key={item.id} id={item.id}>
+            <a href={`#${item.id}`}>{item.question}</a>
+            <p>
+              {item.answer}{' '}
+              {item.rationale && (
+                <a href={item.rationale} target="_blank" rel="noopener noreferrer">
+                  Learn more
+                </a>
+              )}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- serve static FAQ data with optional query filter
- add front-end FAQ page with search and anchors
- document FAQ endpoint in README

## Testing
- `pre-commit run --files README.md app/main.py app/models.py app/routes/faq.py fastapi_tests/test_faq.py pages/faq.tsx app/content/faq.en.json` *(fails: mypy missing types in unrelated modules)*
- `pytest fastapi_tests/test_faq.py --cov=app.routes.faq --cov-branch -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40350c3f883328b54e3cfeb9307ac