### PR TITLE
Unify authentication via configurable API key or JWT

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -23,7 +23,7 @@ from app.models import (
     StrategyDirectives,
 )
 from app.rules.engine import load_rule_pack, validate_feasibility
-from app.security.jwt import require_jwt
+from app.security.auth import require_auth
 from app.services.optimizer import select_topk
 from app.strategy.engine import propose_strategy
 
@@ -208,7 +208,7 @@ def lint(payload: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.post("/export", tags=["Export"], dependencies=[Depends(require_jwt)])
+@router.post("/export", tags=["Export"], dependencies=[Depends(require_auth)])
 def export(payload: dict[str, Any]) -> dict[str, str]:
     """Protected export endpoint.
 

--- a/app/routes/ops.py
+++ b/app/routes/ops.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from app.generate.layers import candidates_to_layers
 from app.generate.lint import lint_layers
 from app.models import CandidateSchedule, FeatureBundle, StrategyDirectives
-from app.security.api_key import require_api_key
+from app.security.auth import require_auth
 from app.services.optimizer import select_topk
 from app.strategy.engine import propose_strategy
 
@@ -57,7 +57,7 @@ def lint(payload: dict[str, Any]) -> dict[str, Any]:
     return lint_layers(payload["artifact"])
 
 
-@router.post("/export", dependencies=[Depends(require_api_key)])
+@router.post("/export", dependencies=[Depends(require_auth)])
 def export(payload: dict[str, Any]) -> dict[str, str]:
     try:
         art = payload.get("artifact", {})

--- a/app/security/api_key.py
+++ b/app/security/api_key.py
@@ -1,26 +1,13 @@
 from __future__ import annotations
 
-import os
+from fastapi import Header, Query
 
-from fastapi import Header, HTTPException, Query, status
+from .auth import require_auth
 
 
 def require_api_key(
     x_api_key: str | None = Header(default=None),
     api_key: str | None = Query(default=None),
 ) -> None:
-    """
-    If VECTORBID_API_KEY is set:
-      - accept either header `x-api-key` or query param `?api_key=`
-      - else 401 Unauthorized
-    If not set: no-op (keeps tests/local dev unchanged).
-    """
-    expected = os.environ.get("VECTORBID_API_KEY")
-    if not expected:
-        return  # auth disabled
-    provided = x_api_key or api_key
-    if provided != expected:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="invalid or missing api key",
-        )
+    """Backward-compatible wrapper for API key auth."""
+    return require_auth(x_api_key=x_api_key, api_key=api_key)

--- a/app/security/auth.py
+++ b/app/security/auth.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import jwt
+from fastapi import Header, HTTPException, Query, status
+
+
+def require_auth(
+    authorization: str | None = Header(default=None),
+    x_api_key: str | None = Header(default=None),
+    api_key: str | None = Query(default=None),
+) -> dict[str, Any] | None:
+    """Unified auth dependency supporting JWT or API key.
+
+    Auth mode is determined by environment configuration:
+    - If ``JWT_SECRET`` is set: expects ``Authorization: Bearer <token>`` and
+      returns the decoded JWT payload.
+    - Else if ``VECTORBID_API_KEY`` is set: expects header ``x-api-key`` or
+      query parameter ``api_key`` to match the configured key.
+    - If neither is set, authentication is disabled (no-op) to preserve the
+      previous default behaviour.
+    """
+    jwt_secret = os.environ.get("JWT_SECRET")
+    api_key_expected = os.environ.get("VECTORBID_API_KEY")
+
+    if jwt_secret:
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="missing bearer token",
+            )
+        token = authorization.split(" ", 1)[1]
+        try:
+            return jwt.decode(token, jwt_secret, algorithms=["HS256"])
+        except Exception as e:  # pragma: no cover - specific errors not needed
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid token",
+            ) from e
+
+    if api_key_expected:
+        provided = x_api_key or api_key
+        if provided != api_key_expected:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid or missing api key",
+            )
+        return None
+
+    # Auth disabled
+    return None

--- a/app/security/jwt.py
+++ b/app/security/jwt.py
@@ -1,37 +1,12 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
-import jwt
-from fastapi import Header, HTTPException, status
+from fastapi import Header
+
+from .auth import require_auth
 
 
 def require_jwt(authorization: str | None = Header(default=None)) -> dict[str, Any]:
-    """Validate a JWT from the Authorization header.
-
-    Expects header: ``Authorization: Bearer <token>``.
-    Secret key is read from ``JWT_SECRET``. Raises 401 on failure.
-    Returns the decoded token payload.
-    """
-
-    secret = os.environ.get("JWT_SECRET")
-    if not secret:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="jwt secret not configured",
-        )
-
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token"
-        )
-
-    token = authorization.split(" ", 1)[1]
-    try:
-        payload = jwt.decode(token, secret, algorithms=["HS256"])
-    except Exception as e:  # pragma: no cover - specific errors aren't relevant
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token"
-        ) from e
-    return payload
+    """Backward-compatible wrapper for JWT auth."""
+    return require_auth(authorization=authorization)

--- a/fastapi_tests/test_export_auth.py
+++ b/fastapi_tests/test_export_auth.py
@@ -59,8 +59,9 @@ def _build_artifact(client: TestClient):
 
 
 def test_export_requires_jwt_and_produces_signature(tmp_path, monkeypatch):
-    # Enable auth & set export dir and signing key
+    # Enable JWT auth & set export dir and signing key
     monkeypatch.setenv("JWT_SECRET", "secret")
+    monkeypatch.delenv("VECTORBID_API_KEY", raising=False)
     monkeypatch.setenv("EXPORT_SIGNING_KEY", "sign")
     monkeypatch.setenv("EXPORT_DIR", str(tmp_path))
 
@@ -85,6 +86,47 @@ def test_export_requires_jwt_and_produces_signature(tmp_path, monkeypatch):
     r = client.post(
         "/api/export",
         headers={"Authorization": f"Bearer {token}"},
+        json={"artifact": artifact},
+    )
+    assert r.status_code == 200
+    out = r.json()
+    assert "export_path" in out and "signature" in out
+    path = pathlib.Path(out["export_path"])
+    assert path.exists()
+    sig_path = pathlib.Path(str(path) + ".sig")
+    assert sig_path.exists()
+    data = path.read_bytes()
+    expected = hmac.new(b"sign", data, hashlib.sha256).hexdigest()
+    assert sig_path.read_text() == expected
+    assert out["signature"] == expected
+
+
+def test_export_requires_api_key_and_produces_signature(tmp_path, monkeypatch):
+    # Enable API key auth & set export dir and signing key
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.setenv("VECTORBID_API_KEY", "secret")
+    monkeypatch.setenv("EXPORT_SIGNING_KEY", "sign")
+    monkeypatch.setenv("EXPORT_DIR", str(tmp_path))
+
+    client = TestClient(app)
+    artifact = _build_artifact(client)
+
+    # Without key -> 401
+    r = client.post("/api/export", json={"artifact": artifact})
+    assert r.status_code == 401
+
+    # With wrong key -> 401
+    r = client.post(
+        "/api/export",
+        headers={"x-api-key": "wrong"},
+        json={"artifact": artifact},
+    )
+    assert r.status_code == 401
+
+    # With valid key -> 200 and signed output
+    r = client.post(
+        "/api/export",
+        headers={"x-api-key": "secret"},
         json={"artifact": artifact},
     )
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- add `require_auth` that enforces JWT or API key based on env vars
- replace router dependencies with `require_auth`
- cover both auth modes with tests

## Testing
- `pre-commit run --files app/security/auth.py app/security/api_key.py app/security/jwt.py app/routes/ops.py app/api/routes.py fastapi_tests/test_export_auth.py` *(fails: mypy errors in existing files)*
- `SKIP=mypy pre-commit run --files app/security/auth.py app/security/api_key.py app/security/jwt.py app/routes/ops.py app/api/routes.py fastapi_tests/test_export_auth.py`
- `pytest fastapi_tests/test_export_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4038d247483328af6847d14d6afb4